### PR TITLE
Remove overflow from body

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  overflow: none;
 }
 
 code {


### PR DESCRIPTION
Prevents people from viewing the app on mobile, aswell as the ability to scroll through the leaderboard